### PR TITLE
Fix: placeholder of Gradient Text component not visible

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -159,7 +159,7 @@ textarea {
 }
 
 ::placeholder {
-  color: var(--input-color);
+  color: #A5A5A7;
   font-size: 1rem;
 }
 


### PR DESCRIPTION
## 🛠️ Fixes Issue
Closes #160 

## 👨‍💻 Changes proposed
- change the placeholder colour to a higher contrast one

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📷 Screenshots
![Screenshot 2022-09-26 at 11 19 33](https://user-images.githubusercontent.com/1682188/192240438-f5ec8c25-d25e-4f23-a595-6131cb2b1ba0.png)
