### PR TITLE
fix(gradienttext): prevented sidebar to open if text is empty

### DIFF
--- a/src/pages/gradient-text.ts
+++ b/src/pages/gradient-text.ts
@@ -11,7 +11,7 @@ export function gradientTextGenerator(): void {
   const getInputElement = utils.getInputText(attribute);
   const getOutputElement = utils.getOutput(attribute);
   const resultPage = utils.getResultPage();
-  
+
   resultPage.style.display = 'flex';
   if (getOutputElement === null) return;
   getOutputElement.style.display = 'grid';
@@ -23,7 +23,7 @@ export function gradientTextGenerator(): void {
 
   if (getInputElement.value.length === 0) {
     utils.triggerEmptyAnimation(getInputElement);
-    return;
+    throw new Error('Text is empty!');
   }
 
   const values = {


### PR DESCRIPTION
## 🛠️ Fixes Issue

Closes #192 

## 👨‍💻 Changes proposed

When a result is requested, returning early from `gradientTextGenerator` has no effect as the sidebar opening logic is elsewhere.

With a simple `throw` this bug can be fixed without drilling or any major refactoring to pass values across the application. 

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
