### PR TITLE
fix: update codeToCopy template literal variable in case 'gradient-border'

### DIFF
--- a/src/lib/general.ts
+++ b/src/lib/general.ts
@@ -57,10 +57,14 @@ function actOnGenerator(attribute: string, outputElement: HTMLElement) {
       element = outputElement.style;
       codeToCopy = `
         div {
-          border: ${element.border},
-          border-width: ${element.borderWidth},
-          border-image-slice: ${element.borderImageSlice},
-          border-image-source: ${element.borderImageSource},
+          border-width:8px;
+          border-style:solid;
+          border-radius:${element.getPropertyValue(`--${attribute}-radius`)};
+          border-image:linear-gradient(${element.getPropertyValue(
+            `--${attribute}-degree`
+          )}, ${element.getPropertyValue(
+        `--${attribute}-color-1`
+      )}, ${element.getPropertyValue(`--${attribute}-color-2`)}) 1;
         }
       `;
       break;


### PR DESCRIPTION
Fixes #198

## 👨‍💻 Changes proposed
updated the codeToCopy template literal of case: 'gradient-border' with the properties that are in element using the method .getPropertyValue()

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📷 Screenshots

Current output : 

![current_output](https://user-images.githubusercontent.com/68579045/193500733-3823001c-a2ea-4b49-b663-3e0a2589e9a4.png)

Expected output :

![expected_output](https://user-images.githubusercontent.com/68579045/193500753-13619e15-e5f6-43b2-98b4-03c212963fd0.png)

## 📄 Note to reviewers
You can see from above screenshots that the expected output fixes the issue.


