### PR TITLE
feat: add animation for NavBar in mobile view

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -126,6 +126,7 @@ menuIcon?.addEventListener('click', () => {
 
 for (let i = 0; i < generators.length; i++) {
   generators[i].addEventListener('click', () => {
+    navBar?.animate(navBarSlideOut, navBarAnimationOptions)
     navBar?.classList.add('closed-nav');
     menuIcon?.setAttribute('icon', 'dashicons:menu-alt');
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,22 @@ const sideBarTiming = {
   easing: 'ease-in',
 };
 
+const navBarSlideIn = [
+  {left: "-50%", opacity: '0', },
+  {left: "0%", opacity: '1'}
+]
+
+const navBarSlideOut = [
+  {left: "0%", opacity: '1'},
+  {left: "-50%", opacity: '0'}
+]
+
+const navBarAnimationOptions = {
+  duration: 300,
+  iterations: 1,
+  easing: 'ease'
+}
+
 // Elements
 const generators = document.querySelectorAll('[data-gen]');
 const sidebar = <HTMLElement>document.querySelector('.side-results');
@@ -98,9 +114,11 @@ const gradientBackgroundDegree = <HTMLInputElement>(
 
 menuIcon?.addEventListener('click', () => {
   if (navBar?.classList.contains('closed-nav')) {
+    navBar?.animate(navBarSlideIn, navBarAnimationOptions)
     navBar?.classList.remove('closed-nav');
     menuIcon?.setAttribute('icon', 'ci:close-big');
   } else {
+    navBar?.animate(navBarSlideOut, navBarAnimationOptions)
     navBar?.classList.add('closed-nav');
     menuIcon?.setAttribute('icon', 'dashicons:menu-alt');
   }


### PR DESCRIPTION
This PR adds a sliding and opacity animation to the NavBar when closed/expanded in mobile view.  
For#209

<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue
Fixes #209 
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## 👨‍💻 Changes proposed
Use `navBar?.animate` with keyframe options to animate a sliding effect as well as changing opacity.
<!-- List all the proposed changes in your PR -->

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers
Do you want me to animate the hamburger menu into the X? I can try doing that if you'd like(may or may not work)
Thanks!
<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots
https://user-images.githubusercontent.com/58442255/193570193-814cb5f3-e89c-49f2-b3ef-71d7ae64fe8b.mp4