### PR TITLE
fix: made the label of file uploader responsive

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -148,6 +148,11 @@ for (let i = 0; i < generators.length; i++) {
 FilePond.create(getImageEntryElement, {
   imagePreviewMaxHeight: 200,
 
+  labelIdle:
+    window.innerWidth < 768
+      ? '<span class="filepond--label-action">Browse</span>'
+      : 'Drag & Drop your files or <span class="filepond--label-action"> Browse </span>',
+
   onpreparefile: (fileItem, output): void => {
     // create a new image object
     const img = new Image();


### PR DESCRIPTION
Made the label of filepond file uploader responsive

## 🛠️ Fixes Issue

Closes #175 

## 👨‍💻 Changes proposed

- Made the label of filepond file uploader responsive
- The label now shows default text on screens with width above 768px, and it gets changed to "Browse" only in smaller screens

## ✔️ CheckList

- [x] My code follows the code style of this project. 
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.