### PR TITLE
fix: gradient text copied code

### DIFF
--- a/src/lib/general.ts
+++ b/src/lib/general.ts
@@ -43,12 +43,10 @@ function actOnGenerator(attribute: string, outputElement: HTMLElement) {
       codeToCopy = `
       p{	
         font-size: ${(outputElement.children[0] as HTMLElement).style.fontSize};
-    background: ${
-      (outputElement.children[0] as HTMLElement).style.backgroundImage
-    };
-    background-clip: 'text';
-    -webkit-background-clip: 'text';
-    -webkit-text-fill-color: 'transparent';
+        background: ${(outputElement.children[0] as HTMLElement).style.background};
+        background-clip: text;
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
       }
       `;
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

Closes #252 

## 👨‍💻 Changes proposed

- removed extra single-inverted-commas from Gradient text code syntax

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots
Before 
![image](https://user-images.githubusercontent.com/78981177/194873776-42d3fb85-7503-412a-9456-2ad356042fa4.png)

After
![image](https://user-images.githubusercontent.com/78981177/194873805-1dded2d3-fc36-4b5d-81e2-1a96b1d5e075.png)

