### PR TITLE
feat(box-shadow): show amount of pixels immediately in box shadow

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,7 +441,10 @@
             <div class="box-shadow-degrees">
               <div class="box-shadow-row">
                 <label id="degree">
-                  <span>Horizontal</span>
+                  <span>
+                    <span>Horizontal</span>
+                    <span id="box-shadow-h-offset-field">5px</span>
+                  </span>
                   <input
                     type="range"
                     max="50"
@@ -453,7 +456,10 @@
                 </label>
 
                 <label id="degree">
-                  <span>Vertical</span>
+                  <span>
+                    <span>Vertical</span>
+                    <span id="box-shadow-v-offset-field">5px</span>
+                  </span>
                   <input
                     type="range"
                     max="50"
@@ -467,7 +473,10 @@
               <hr class="divider" />
               <div class="box-shadow-row">
                 <label id="degree">
-                  <span>Blur</span>
+                  <span>
+                    <span>Blur</span>
+                    <span id="box-shadow-blur-field">5px</span>
+                  </span>
                   <input
                     type="range"
                     max="100"
@@ -479,7 +488,10 @@
                 </label>
 
                 <label id="degree">
-                  <span>Spread</span>
+                  <span>
+                    <span>Horizontal</span>
+                    <span id="box-shadow-spread-field">5px</span>
+                  </span>
                   <input
                     type="range"
                     max="50"

--- a/src/lib/general.ts
+++ b/src/lib/general.ts
@@ -43,7 +43,9 @@ function actOnGenerator(attribute: string, outputElement: HTMLElement) {
       codeToCopy = `
       p{	
         font-size: ${(outputElement.children[0] as HTMLElement).style.fontSize};
-        background: ${(outputElement.children[0] as HTMLElement).style.background};
+        background: ${
+          (outputElement.children[0] as HTMLElement).style.background
+        };
         background-clip: text;
         -webkit-background-clip: text;
         -webkit-text-fill-color: transparent;
@@ -82,16 +84,16 @@ function actOnGenerator(attribute: string, outputElement: HTMLElement) {
           border-radius: ${element.borderRadius};
       `;
       break;
-    case 'box-shadow':   
-      element = outputElement.style; 
-      console.log("element: ", element)
+    case 'box-shadow':
+      element = outputElement.style;
+      console.log('element: ', element);
       codeToCopy = `
         div {
           height: '300px';
           width: '300px';
           box-shadow: ${element.boxShadow};
         }
-      `;  
+      `;
       break;
   }
 
@@ -238,10 +240,14 @@ export const getStyleSheet = () => {
   return <CSSStyleSheet>stylesheet[0];
 };
 
-export const getBoxShadowHorizontalOffset = (attribute: string): HTMLInputElement =>
+export const getBoxShadowHorizontalOffset = (
+  attribute: string
+): HTMLInputElement =>
   <HTMLInputElement>document.getElementById(`${attribute}-h-offset`);
 
-export const getBoxShadowVerticalOffset = (attribute: string): HTMLInputElement =>
+export const getBoxShadowVerticalOffset = (
+  attribute: string
+): HTMLInputElement =>
   <HTMLInputElement>document.getElementById(`${attribute}-v-offset`);
 
 export const getBoxShadowBlur = (attribute: string): HTMLInputElement =>
@@ -252,6 +258,15 @@ export const getBoxShadowSpread = (attribute: string): HTMLInputElement =>
 
 export const getBoxShadowColor = (attribute: string): HTMLInputElement =>
   <HTMLInputElement>document.getElementById(`${attribute}-color`);
+
+export const getBoxShadowFields = (...types: string[]): HTMLSpanElement[] =>
+  types.reduce(
+    (acc, type) => [
+      ...acc,
+      document.getElementById(`box-shadow-${type}-field`) as HTMLInputElement,
+    ],
+    []
+  );
 
 function createDownloadLink(fileName: string, url: string) {
   const link = document.createElement('a');

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import {gradientBorderGenerator} from './pages/gradient-border';
 import {gradientBackgroundGenerator} from './pages/gradient-background';
 import {animationGenerator} from './pages/animation';
 import {borderRadiusGenerator} from './pages/border-radius';
-import {boxShadowGenerator} from './pages/box-shadow';
+import {boxShadowGenerator, addBoxShadowListener} from './pages/box-shadow';
 
 // Utils
 import {
@@ -450,3 +450,5 @@ const BorderRadiusGenerator = (
 gradientBorderRadius.addEventListener('change', function () {
   gradientBorderInput.style.display = this.checked ? 'inline' : 'none';
 });
+
+addBoxShadowListener();

--- a/src/pages/box-shadow.ts
+++ b/src/pages/box-shadow.ts
@@ -1,35 +1,34 @@
 import * as utils from '../lib/general';
 
 type Values = {
-	hOffset: string,  
-	vOffset: string,
-	blur: string, 
-	spread: string;
-	color: string;
-}
+  hOffset: string;
+  vOffset: string;
+  blur: string;
+  spread: string;
+  color: string;
+};
 
-export function boxShadowGenerator() : void {
-	const attribute = 'box-shadow';
-	const horizontalOffset = utils.getBoxShadowHorizontalOffset(attribute);
-	const verticalOffset = utils.getBoxShadowVerticalOffset(attribute);
-	const blur = utils.getBoxShadowBlur(attribute);
-	const spread = utils.getBoxShadowSpread(attribute);
-	const color = utils.getBoxShadowColor(attribute);
-	const getOutputElement = utils.getOutput(attribute);
-	const resultPage = utils.getResultPage();
+export function boxShadowGenerator(): void {
+  const attribute = 'box-shadow';
+  const horizontalOffset = utils.getBoxShadowHorizontalOffset(attribute);
+  const verticalOffset = utils.getBoxShadowVerticalOffset(attribute);
+  const blur = utils.getBoxShadowBlur(attribute);
+  const spread = utils.getBoxShadowSpread(attribute);
+  const color = utils.getBoxShadowColor(attribute);
+  const getOutputElement = utils.getOutput(attribute);
+  const resultPage = utils.getResultPage();
 
-	resultPage.style.display = 'flex';
+  resultPage.style.display = 'flex';
 
-	const values: Values = {
-		hOffset: horizontalOffset.value,  
-		vOffset: verticalOffset.value,
-		blur: blur.value,  
-		spread: spread.value,  
-		color: color.value,   
-	}; 
+  const values: Values = {
+    hOffset: horizontalOffset.value,
+    vOffset: verticalOffset.value,
+    blur: blur.value,
+    spread: spread.value,
+    color: color.value,
+  };
 
-	getBoxShadowResult(attribute, values, getOutputElement);
-	
+  getBoxShadowResult(attribute, values, getOutputElement);
 }
 
 /**
@@ -40,25 +39,49 @@ export function boxShadowGenerator() : void {
  * @param outputElement output element to display result
  */
 function getBoxShadowResult(
-	attribute: string,  
-	values: Values,  
-	outputElement: HTMLElement
+  attribute: string,
+  values: Values,
+  outputElement: HTMLElement
 ): void {
-	const createBoxShadowElement = (boxShadowElement: any, values: any) => {
-		boxShadowElement.style.height = '300px';
-		boxShadowElement.style.width = '300px';
-		boxShadowElement.style.background = 'transparent';
-		boxShadowElement.style.boxShadow = `${values.hOffset}px ${values.vOffset}px ${values.blur}px ${values.spread}px ${values.color}`;
-	}
-	createBoxShadowElement(outputElement, values)
-	
-	const getCodeButtonElement = utils.getCopyCodeButton(attribute);  
-	getCodeButtonElement.addEventListener('click', () => {
-		utils.copyCodeToClipboard(attribute, outputElement);
-		utils.showPopup(
-			'Code Copied',  
-			'Code has been successfully copied to clipboard',   
-			'success'
-		);
-	}); 
+  const createBoxShadowElement = (boxShadowElement: any, values: any) => {
+    boxShadowElement.style.height = '300px';
+    boxShadowElement.style.width = '300px';
+    boxShadowElement.style.background = 'transparent';
+    boxShadowElement.style.boxShadow = `${values.hOffset}px ${values.vOffset}px ${values.blur}px ${values.spread}px ${values.color}`;
+  };
+  createBoxShadowElement(outputElement, values);
+
+  const getCodeButtonElement = utils.getCopyCodeButton(attribute);
+  getCodeButtonElement.addEventListener('click', () => {
+    utils.copyCodeToClipboard(attribute, outputElement);
+    utils.showPopup(
+      'Code Copied',
+      'Code has been successfully copied to clipboard',
+      'success'
+    );
+  });
+}
+
+export function addBoxShadowListener(): void {
+  const attribute = 'box-shadow';
+  const horizontalOffset = utils.getBoxShadowHorizontalOffset(attribute);
+  const verticalOffset = utils.getBoxShadowVerticalOffset(attribute);
+  const blur = utils.getBoxShadowBlur(attribute);
+  const spread = utils.getBoxShadowSpread(attribute);
+
+  const allBoxShadowInputs = [horizontalOffset, verticalOffset, blur, spread];
+  const allBoxShadowInputsFields = utils.getBoxShadowFields(
+    'h-offset',
+    'v-offset',
+    'blur',
+    'spread'
+  );
+
+  allBoxShadowInputs.forEach((input, idx) => {
+    // default
+    allBoxShadowInputsFields[idx].textContent = `${input.value}px`;
+    input.addEventListener('input', () => {
+      allBoxShadowInputsFields[idx].textContent = `${input.value}px`;
+    });
+  });
 }

--- a/src/style.css
+++ b/src/style.css
@@ -335,6 +335,7 @@ input[type='number']::-webkit-outer-spin-button {
   background-color: var(--primary-color);
   padding: 0.8rem;
   margin-top: 2rem;
+  margin-bottom: 2rem;
   border-radius: 5px;
   width: min(45%, 55%);
 }
@@ -432,6 +433,18 @@ input[type='number']::-webkit-outer-spin-button {
 
 .box-shadow-row label {
   width: 40% !important;
+}
+
+.box-shadow-row label > span:nth-of-type(1) {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.3rem;
+}
+
+.box-shadow-row label > span:nth-of-type(1) > span:nth-last-of-type(1) {
+  opacity: 0.8;
+  font-size: 12px;
 }
 
 .divider {


### PR DESCRIPTION
Fixes #278

<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->
Closes #278 

## 👨‍💻 Changes proposed

<!-- List all the proposed changes in your PR -->
The amount of box shadow in px is displayed and the box shadow inputs are interacted with.

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers
N/A

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots
![box shadow field](https://user-images.githubusercontent.com/54052461/195524216-fcbb0c53-cf1e-4e2a-812f-b2f82d504262.PNG)
