### PR TITLE
feat(gradient-border): trigger animation on empty color selector

### DIFF
--- a/src/pages/gradient-border.ts
+++ b/src/pages/gradient-border.ts
@@ -19,6 +19,12 @@ export function gradientBorderGenerator(): void {
   const hideRadiusInput = utils.hideRadius;
   const resultPage = utils.getResultPage();
 
+  if (color1.value == '' || color2.value == '') {
+    if (color1.value == '') utils.triggerEmptyAnimation(color1);
+    if (color2.value == '') utils.triggerEmptyAnimation(color2);
+    return;
+  }
+
   resultPage.style.display = 'flex';
 
   getCheckboxElement.addEventListener('change', (e: Event): void => {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue
Closes #288 

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## 👨‍💻 Changes proposed

<!-- List all the proposed changes in your PR -->
If any or both of the color selector in gradient border are empty, animation is triggered on that selector for picking a color instead of giving result according to default red and blue colors.

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots
![Screenshot from 2022-10-14 22-09-11](https://user-images.githubusercontent.com/62374784/195898258-7500f489-e977-4f64-88b9-5809b052be7d.png)

