### PR TITLE
feat(box-shadow): add preview in box-shadow

### DIFF
--- a/index.html
+++ b/index.html
@@ -428,6 +428,7 @@
 
           <!-- Box Shadow -->
           <div data-content="box-shadow">
+            <div class="box-shadow-preview" id="box-shadow-preview"></div>
             <label for="color" class="color">
               <input
                 type="text"

--- a/src/lib/general.ts
+++ b/src/lib/general.ts
@@ -259,6 +259,9 @@ export const getBoxShadowSpread = (attribute: string): HTMLInputElement =>
 export const getBoxShadowColor = (attribute: string): HTMLInputElement =>
   <HTMLInputElement>document.getElementById(`${attribute}-color`);
 
+export const getBoxShadowPreview = (): HTMLInputElement =>
+  <HTMLInputElement>document.getElementById(`box-shadow-preview`);
+
 export const getBoxShadowFields = (...types: string[]): HTMLSpanElement[] =>
   types.reduce(
     (acc, type) => [

--- a/src/pages/box-shadow.ts
+++ b/src/pages/box-shadow.ts
@@ -68,8 +68,17 @@ export function addBoxShadowListener(): void {
   const verticalOffset = utils.getBoxShadowVerticalOffset(attribute);
   const blur = utils.getBoxShadowBlur(attribute);
   const spread = utils.getBoxShadowSpread(attribute);
+  const color = utils.getBoxShadowColor(attribute);
 
-  const allBoxShadowInputs = [horizontalOffset, verticalOffset, blur, spread];
+  const preview = utils.getBoxShadowPreview();
+
+  const allBoxShadowInputs = [
+    horizontalOffset,
+    verticalOffset,
+    blur,
+    spread,
+    color,
+  ];
   const allBoxShadowInputsFields = utils.getBoxShadowFields(
     'h-offset',
     'v-offset',
@@ -77,11 +86,20 @@ export function addBoxShadowListener(): void {
     'spread'
   );
 
+  const getBoxShadowValue = () =>
+    `${horizontalOffset.value}px ${verticalOffset.value}px ${blur.value}px ${spread.value}px ${color.value}`;
+  preview.style.boxShadow = getBoxShadowValue();
+
   allBoxShadowInputs.forEach((input, idx) => {
     // default
-    allBoxShadowInputsFields[idx].textContent = `${input.value}px`;
-    input.addEventListener('input', () => {
+    if (idx < 4) {
       allBoxShadowInputsFields[idx].textContent = `${input.value}px`;
+    }
+    input.addEventListener('input', () => {
+      if (idx < 4) {
+        allBoxShadowInputsFields[idx].textContent = `${input.value}px`;
+      }
+      preview.style.boxShadow = getBoxShadowValue();
     });
   });
 }

--- a/src/style.css
+++ b/src/style.css
@@ -447,14 +447,11 @@ input[type='number']::-webkit-outer-spin-button {
   font-size: 12px;
 }
 
-[data-content='box-shadow'] {
-  position: relative;
-}
 
 .box-shadow-preview {
   --box-size: 100px;
   position: absolute;
-  top: -6rem;
+  top: 1rem;
   left: 2.2rem;
   width: var(--box-size);
   height: var(--box-size);

--- a/src/style.css
+++ b/src/style.css
@@ -756,3 +756,9 @@ a {
     font-size: 1.3rem;
   }
 }
+
+@media screen and (max-width: 500px) {
+  .box-shadow-preview {
+    --box-size: 70px;
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -447,6 +447,20 @@ input[type='number']::-webkit-outer-spin-button {
   font-size: 12px;
 }
 
+[data-content='box-shadow'] {
+  position: relative;
+}
+
+.box-shadow-preview {
+  --box-size: 100px;
+  position: absolute;
+  top: -6rem;
+  left: 2.2rem;
+  width: var(--box-size);
+  height: var(--box-size);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
 .divider {
   width: 60%;
   border: none;


### PR DESCRIPTION
Adds a preview box that is updated when the box-shadow sliders and color are updated.

fix #279 

<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes Issue

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

Closes #279 

## 👨‍💻 Changes proposed

<!-- List all the proposed changes in your PR -->
Box shadow preview

## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

## 📷 Screenshots
![box-shadow preview](https://user-images.githubusercontent.com/54052461/195972361-38d9c888-4da4-45b6-affc-b214ba0ffaad.PNG)
