### PR TITLE
fix: preview goes under the menu icon in mobile view

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -224,7 +224,7 @@ textarea {
 }
 
 ::placeholder {
-  color: ##484848;
+  color: #484848;
   font-size: 0.875rem;
 }
 
@@ -805,5 +805,8 @@ a {
 @media screen and (max-width: 500px) {
   .box-shadow-preview {
     --box-size: 70px;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -451,7 +451,7 @@ input[type='number']::-webkit-outer-spin-button {
   --box-size: 100px;
   position: absolute;
   top: 1rem;
-  left: 2.2rem;
+  left: 3.2rem;
   width: var(--box-size);
   height: var(--box-size);
   border: 1px solid rgba(0, 0, 0, 0.2);
@@ -805,8 +805,5 @@ a {
 @media screen and (max-width: 500px) {
   .box-shadow-preview {
     --box-size: 70px;
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
   }
 }


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Fixes #294 

## 👨‍💻 Changes proposed
Added  `left: 3.2rem;` in box-shadow-preview class of style.css in pages folder.
Removed the previous changes.
Also, changed the title of the pull request.


## ✔️ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

- [ x] My code follows the code style of this project.
- [ x] This PR does not contain plagiarized content.
- [ x] The title of my pull request is a short description of the requested changes.


## 📷 Screenshots

<img width="960" alt="image" src="https://user-images.githubusercontent.com/89680196/196954548-a3c7015c-a9dd-432c-8113-ca9c70118222.png">


