### PR TITLE
fix: fixed css syntax for box shadow generator

### DIFF
--- a/src/lib/general.ts
+++ b/src/lib/general.ts
@@ -89,8 +89,8 @@ function actOnGenerator(attribute: string, outputElement: HTMLElement) {
       console.log('element: ', element);
       codeToCopy = `
         div {
-          height: '300px';
-          width: '300px';
+          height: 300px;
+          width: 300px;
           box-shadow: ${element.boxShadow};
         }
       `;


### PR DESCRIPTION
single quotes were added around height and width property of the `box-shadow` div that resulted in incorrect syntax. Removed them to fix the issue.

# Fixes Issue
Fixes #339

# 👨‍💻 Changes proposed(What did you do ?)

# ✔️ Check List (Check all the applicable boxes)
Removed quotes around property values.
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.