### PR TITLE
fix: blank snackbar

### DIFF
--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -3,7 +3,7 @@ import copy from 'copy-to-clipboard';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import * as eggyJs from '@s-r0/eggy-js';
+import {Eggy} from '@s-r0/eggy-js';
 import {
   getGradientPreview,
   getNewColorButton,
@@ -227,7 +227,7 @@ const actOnGenerator = (attribute: string, outputElement: HTMLElement) => {
   try {
     copy(codeToCopy);
   } catch {
-    eggyJs.Eggy({
+    Eggy({
       title: `Whoops`,
       message: `Can't copy, try again`,
       type: 'error',
@@ -258,10 +258,10 @@ export function downloadSVG(attribute: string, outputImage: HTMLElement): void {
  */
 
 export function showPopup(title: string, message: string, type: string): void {
-  eggyJs.Eggy({
-    title: title,
-    message: message,
-    type: type,
+  Eggy({
+    title,
+    message,
+    type,
   });
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -246,7 +246,7 @@ main > section:last-of-type {
   right: 50px;
 }
 
-.open p {
+.open > p {
   opacity: 0;
 }
 


### PR DESCRIPTION
# Fixes Issue

**My PR closes #377 **

# 👨‍💻 Changes proposed(What did you do ?)

- Fixed the blank snackbar error.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

-  The bug wasn't caused by an error in the package. It was just a CSS issue. A good way to prevent this error in the future is to use class selectors instead of element selectors when styling specific elements.
- Refactored the import statement for the eggy package, so it only imports the object (`{ Eggy }`) being used in the packages.ts file rather than the entire package (`* as eggyJs`). Not related to the error though, so I hope that's not a problem 😅

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
![image](https://user-images.githubusercontent.com/68024640/212923609-2233e33f-fb7f-4fcf-afae-f22a128b0947.png)
