### PR TITLE
feat: Copy TailwindCSS for BoxShadow property

### DIFF
--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -79,8 +79,11 @@ export function copyCSSCodeToClipboard(
  * @param attribute The attribute name of the generator element
  * @param outputElement output element to display result
  */
-export function copyTailwindCodeToClipboard(attribute: string): void {
-  actOnTailwindGenerator(attribute);
+export function copyTailwindCodeToClipboard(
+  attribute: string,
+  outputElement: HTMLElement
+): void {
+  actOnTailwindGenerator(attribute, outputElement);
 }
 
 export const addRule = (function (style) {
@@ -267,8 +270,12 @@ const actOnGenerator = (attribute: string, outputElement: HTMLElement) => {
  * @param attribute attribute of the clicked generator
  * @param outputElement output element to display result
  */
-const actOnTailwindGenerator = (attribute: string) => {
+const actOnTailwindGenerator = (
+  attribute: string,
+  outputElement: HTMLElement
+) => {
   let codeToCopy = '';
+  let element = outputElement.style;
 
   switch (attribute) {
     case 'pic-text':
@@ -287,7 +294,7 @@ const actOnTailwindGenerator = (attribute: string) => {
       codeToCopy = ``;
       break;
     case 'box-shadow':
-      codeToCopy = ``;
+      codeToCopy = `shadow-[${element.boxShadow.replace(/ /g, '_')}]`; //  .replace(/ /g,"_") for replacing spaces with '_'.
       break;
     case 'text-shadow':
       codeToCopy = ``;

--- a/src/pages/box-shadow.ts
+++ b/src/pages/box-shadow.ts
@@ -181,7 +181,8 @@ getValues();
 
 // Tailwind codecopy handler
 function tailwindHandler() {
-  copyTailwindCodeToClipboard(attribute);
+  const outputElement = getOutput(attribute);
+  copyTailwindCodeToClipboard(attribute, outputElement);
   showPopup(
     'Tailwind Code Copied',
     'Code has been successfully copied to clipboard',


### PR DESCRIPTION
# Fixes Issue #413 

**My PR closes #413**

# 👨‍💻 Changes proposed(What did you do ?)
    Added feature to copy tailwindCSS for box-shadow by getting the element css style and replacing the space with '_' , works properly as intended.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
![image](https://github.com/Dun-sin/Code-Magic/assets/88649624/7ebcd067-6105-43f2-af82-3013631ebde0)

