### PR TITLE
feat: Avoid gradient background results without input. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,7 +587,6 @@
                   placeholder="Tap to pick a color"
                   id="gradient-background-color1"
                   class="gradient-background-inputs"
-                  required
                 />
               </label>
 
@@ -598,7 +597,6 @@
                   placeholder="Tap to pick a color"
                   id="gradient-background-color2"
                   class="gradient-background-inputs"
-                  required
                 />
               </label>
             </div>
@@ -641,7 +639,11 @@
 
             <div class="btn-container">
               <div class="reset" data-reset="gradient-background">Reset</div>
-              <div class="btn" data-button="gradient-background">
+              <div
+                class="btn"
+                data-button="gradient-background"
+                id="getResultBtn"
+              >
                 Get Result
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -587,6 +587,7 @@
                   placeholder="Tap to pick a color"
                   id="gradient-background-color1"
                   class="gradient-background-inputs"
+                  required
                 />
               </label>
 
@@ -597,6 +598,7 @@
                   placeholder="Tap to pick a color"
                   id="gradient-background-color2"
                   class="gradient-background-inputs"
+                  required
                 />
               </label>
             </div>

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -35,7 +35,7 @@ const attribute = 'gradient-background';
 
 const getNewColorButtonElement = getNewColorButton(attribute);
 const getRemoveColorButtonElement = getRemoveNewColorButton(attribute);
-
+const getResultBtn = document.getElementById('getResultBtn');
 let gradientBackgroundInputs = getAllInputElements('gradient-background');
 
 const getDegreeElement = getRange(attribute);
@@ -51,9 +51,12 @@ export function gradientBackgroundGenerator(
   var value = element.value; // Get the value of the input field
   if (value.length < 3) {
     gradientBackgroundInputs.forEach((ele) => {
+      getResultBtn.style.backgroundColor = 'grey';
       triggerEmptyAnimation(ele);
     });
     return;
+  } else {
+    getResultBtn.style.backgroundColor = 'blue';
   }
 
   const getOutputElement = getOutput(attribute);

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -52,12 +52,16 @@ export function gradientBackgroundGenerator(
   var value = element.value;
   if (value.length < 3) {
     gradientBackgroundInputs.forEach((ele) => {
-      getResultBtn.style.backgroundColor = 'grey';
+      if (getResultBtn) {
+        getResultBtn.style.backgroundColor = 'grey';
+      }
       triggerEmptyAnimation(ele);
     });
     return;
   } else {
-    getResultBtn.style.backgroundColor = 'blue';
+    if (getResultBtn) {
+      getResultBtn.style.backgroundColor = 'blue';
+    }
   }
 
   const getOutputElement = getOutput(attribute);

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -47,8 +47,9 @@ export function gradientBackgroundGenerator(
   type: 'newResults' | 'oldResults' | null
 ) {
   if (type === null) return;
+  // Show error when the colors are not entered.
   var element = gradientBackgroundInputs[0];
-  var value = element.value; // Get the value of the input field
+  var value = element.value;
   if (value.length < 3) {
     gradientBackgroundInputs.forEach((ele) => {
       getResultBtn.style.backgroundColor = 'grey';

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -12,9 +12,9 @@ import {
   getCssOrTailwindDropdown,
   getTailwindButton,
   getCssOrTailwindButton,
-  getInputText,
 } from '../lib/getElements';
 import {
+  triggerEmptyAnimation,
   copyCSSCodeToClipboard,
   showPopup,
   whatColorButtonShouldShow,
@@ -25,7 +25,6 @@ import {
   getColorsValue,
   closeDropdown,
   copyTailwindCodeToClipboard,
-  triggerEmptyAnimation,
 } from '../lib/packages/utils';
 
 type Values = {
@@ -48,10 +47,12 @@ export function gradientBackgroundGenerator(
   type: 'newResults' | 'oldResults' | null
 ) {
   if (type === null) return;
-
   var element = gradientBackgroundInputs[0];
   var value = element.value; // Get the value of the input field
   if (value.length < 3) {
+    gradientBackgroundInputs.forEach((ele) => {
+      triggerEmptyAnimation(ele);
+    });
     return;
   }
 

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -12,6 +12,7 @@ import {
   getCssOrTailwindDropdown,
   getTailwindButton,
   getCssOrTailwindButton,
+  getInputText,
 } from '../lib/getElements';
 import {
   copyCSSCodeToClipboard,
@@ -24,6 +25,7 @@ import {
   getColorsValue,
   closeDropdown,
   copyTailwindCodeToClipboard,
+  triggerEmptyAnimation,
 } from '../lib/packages/utils';
 
 type Values = {
@@ -46,6 +48,12 @@ export function gradientBackgroundGenerator(
   type: 'newResults' | 'oldResults' | null
 ) {
   if (type === null) return;
+
+  var element = gradientBackgroundInputs[0];
+  var value = element.value; // Get the value of the input field
+  if (value.length < 3) {
+    return;
+  }
 
   const getOutputElement = getOutput(attribute);
   const resultPage = getResultPage();


### PR DESCRIPTION
# Fixes Issue

**My PR closes #430**

# 👨‍💻 Changes proposed(What did you do ?)

- Do not show the result screen if the inputs are not entered.
- Change the `Get Result` button to grey color if the inputs are not entered.
- Add an error indicator if the `Get Result` button is clicked and the input is not provided.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots
The button color is turned to grey when the input is not entered:
![codemagic1](https://github.com/Dun-sin/Code-Magic/assets/61418965/1f1a909a-8279-45b8-b449-a67f40fd62ce)

When the user tries to click on `Get Result` button without entering the input:

https://github.com/Dun-sin/Code-Magic/assets/61418965/59e76491-c971-4c45-ac03-f96c610b1e23




<!-- Add all the screenshots which support your changes -->

