### PR TITLE
feat: Avoid gradient background results when single input is provided.

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,11 +639,7 @@
 
             <div class="btn-container">
               <div class="reset" data-reset="gradient-background">Reset</div>
-              <div
-                class="btn"
-                data-button="gradient-background"
-                id="getResultBtn"
-              >
+              <div class="btn" data-button="gradient-background">
                 Get Result
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -587,7 +587,6 @@
                   placeholder="Tap to pick a color"
                   id="gradient-background-color1"
                   class="gradient-background-inputs"
-                  required
                 />
               </label>
 
@@ -598,7 +597,6 @@
                   placeholder="Tap to pick a color"
                   id="gradient-background-color2"
                   class="gradient-background-inputs"
-                  required
                 />
               </label>
             </div>
@@ -641,7 +639,11 @@
 
             <div class="btn-container">
               <div class="reset" data-reset="gradient-background">Reset</div>
-              <div class="btn" data-button="gradient-background">
+              <div
+                class="btn"
+                data-button="gradient-background"
+                id="getResultBtn"
+              >
                 Get Result
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -587,6 +587,7 @@
                   placeholder="Tap to pick a color"
                   id="gradient-background-color1"
                   class="gradient-background-inputs"
+                  required
                 />
               </label>
 
@@ -597,6 +598,7 @@
                   placeholder="Tap to pick a color"
                   id="gradient-background-color2"
                   class="gradient-background-inputs"
+                  required
                 />
               </label>
             </div>

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -35,7 +35,7 @@ const attribute = 'gradient-background';
 
 const getNewColorButtonElement = getNewColorButton(attribute);
 const getRemoveColorButtonElement = getRemoveNewColorButton(attribute);
-
+const getResultBtn = document.getElementById('getResultBtn');
 let gradientBackgroundInputs = getAllInputElements('gradient-background');
 
 const getDegreeElement = getRange(attribute);
@@ -51,9 +51,12 @@ export function gradientBackgroundGenerator(
   var value = element.value; // Get the value of the input field
   if (value.length < 3) {
     gradientBackgroundInputs.forEach((ele) => {
+      getResultBtn.style.backgroundColor = 'grey';
       triggerEmptyAnimation(ele);
     });
     return;
+  } else {
+    getResultBtn.style.backgroundColor = 'blue';
   }
 
   const getOutputElement = getOutput(attribute);

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -49,14 +49,15 @@ export function gradientBackgroundGenerator(
   if (type === null) return;
   // Show error when the colors are not entered.
   var element = gradientBackgroundInputs[0];
-  var value = element.value;
-  if (value.length < 3) {
+  var element2 = gradientBackgroundInputs[1];
+  console.log(element.value.length);
+  if (element.value.length == 0 || element2.value.length == 0) {
     gradientBackgroundInputs.forEach((ele) => {
-      if (getResultBtn) {
-        getResultBtn.style.backgroundColor = 'grey';
-      }
       triggerEmptyAnimation(ele);
     });
+    if (getResultBtn) {
+      getResultBtn.style.backgroundColor = 'grey';
+    }
     return;
   } else {
     if (getResultBtn) {

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -52,12 +52,16 @@ export function gradientBackgroundGenerator(
   var value = element.value;
   if (value.length < 3) {
     gradientBackgroundInputs.forEach((ele) => {
-      getResultBtn.style.backgroundColor = 'grey';
+      if (getResultBtn) {
+        getResultBtn.style.backgroundColor = 'grey';
+      }
       triggerEmptyAnimation(ele);
     });
     return;
   } else {
-    getResultBtn.style.backgroundColor = 'blue';
+    if (getResultBtn) {
+      getResultBtn.style.backgroundColor = 'blue';
+    }
   }
 
   const getOutputElement = getOutput(attribute);

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -47,8 +47,9 @@ export function gradientBackgroundGenerator(
   type: 'newResults' | 'oldResults' | null
 ) {
   if (type === null) return;
+  // Show error when the colors are not entered.
   var element = gradientBackgroundInputs[0];
-  var value = element.value; // Get the value of the input field
+  var value = element.value;
   if (value.length < 3) {
     gradientBackgroundInputs.forEach((ele) => {
       getResultBtn.style.backgroundColor = 'grey';

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -12,9 +12,9 @@ import {
   getCssOrTailwindDropdown,
   getTailwindButton,
   getCssOrTailwindButton,
-  getInputText,
 } from '../lib/getElements';
 import {
+  triggerEmptyAnimation,
   copyCSSCodeToClipboard,
   showPopup,
   whatColorButtonShouldShow,
@@ -25,7 +25,6 @@ import {
   getColorsValue,
   closeDropdown,
   copyTailwindCodeToClipboard,
-  triggerEmptyAnimation,
 } from '../lib/packages/utils';
 
 type Values = {
@@ -48,10 +47,12 @@ export function gradientBackgroundGenerator(
   type: 'newResults' | 'oldResults' | null
 ) {
   if (type === null) return;
-
   var element = gradientBackgroundInputs[0];
   var value = element.value; // Get the value of the input field
   if (value.length < 3) {
+    gradientBackgroundInputs.forEach((ele) => {
+      triggerEmptyAnimation(ele);
+    });
     return;
   }
 

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -12,6 +12,7 @@ import {
   getCssOrTailwindDropdown,
   getTailwindButton,
   getCssOrTailwindButton,
+  getInputText,
 } from '../lib/getElements';
 import {
   copyCSSCodeToClipboard,
@@ -24,6 +25,7 @@ import {
   getColorsValue,
   closeDropdown,
   copyTailwindCodeToClipboard,
+  triggerEmptyAnimation,
 } from '../lib/packages/utils';
 
 type Values = {
@@ -46,6 +48,12 @@ export function gradientBackgroundGenerator(
   type: 'newResults' | 'oldResults' | null
 ) {
   if (type === null) return;
+
+  var element = gradientBackgroundInputs[0];
+  var value = element.value; // Get the value of the input field
+  if (value.length < 3) {
+    return;
+  }
 
   const getOutputElement = getOutput(attribute);
   const resultPage = getResultPage();

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -35,7 +35,6 @@ const attribute = 'gradient-background';
 
 const getNewColorButtonElement = getNewColorButton(attribute);
 const getRemoveColorButtonElement = getRemoveNewColorButton(attribute);
-const getResultBtn = document.getElementById('getResultBtn');
 let gradientBackgroundInputs = getAllInputElements('gradient-background');
 
 const getDegreeElement = getRange(attribute);
@@ -55,14 +54,7 @@ export function gradientBackgroundGenerator(
     gradientBackgroundInputs.forEach((ele) => {
       triggerEmptyAnimation(ele);
     });
-    if (getResultBtn) {
-      getResultBtn.style.backgroundColor = 'grey';
-    }
     return;
-  } else {
-    if (getResultBtn) {
-      getResultBtn.style.backgroundColor = 'blue';
-    }
   }
 
   const getOutputElement = getOutput(attribute);


### PR DESCRIPTION
# Fixes Issue

**My PR closes #430 **

# 👨‍💻 Changes proposed(What did you do ?)

- Do not show the result screen if only a single input is entered.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

The previous PR related to this issue was closed. Despite that, the Gradient background result screen was still visible even if the user entered only one input color. I have addressed this problem in this new PR.

# 📷 Screenshots

https://github.com/Dun-sin/Code-Magic/assets/61418965/cba1f479-71da-41f0-9591-c648c9fcf197


