### PR TITLE
fix: open results button showing wrongly #441

### DIFF
--- a/src/pages/box-shadow.ts
+++ b/src/pages/box-shadow.ts
@@ -19,7 +19,6 @@ import {
   getAllInputElements,
 } from '../lib/getElements';
 import {
-  triggerEmptyAnimation,
   copyCSSCodeToClipboard,
   copyTailwindCodeToClipboard,
   showPopup,

--- a/src/pages/box-shadow.ts
+++ b/src/pages/box-shadow.ts
@@ -14,6 +14,8 @@ import {
   getTailwindButton,
   getCssOrTailwindButton,
   getCssOrTailwindDropdown,
+  getOpenSideBarButton,
+  getAllInputElements,
 } from '../lib/getElements';
 import {
   copyCSSCodeToClipboard,
@@ -35,6 +37,7 @@ const attribute = 'box-shadow';
 let isSliderOpen = false;
 const getCssOrTailwindDropdownElement = getCssOrTailwindDropdown(attribute);
 const showCopyClass = 'show-css-tailwind';
+const boxshadowInputs = getAllInputElements(attribute);
 
 function copyHandler() {
   const outputElement = getOutput(attribute);
@@ -66,8 +69,17 @@ export function boxShadowGenerator(
   const color = getShadowColor(attribute);
   const getOutputElement = getOutput(attribute);
   const resultPage = getResultPage();
+  
+  const element = boxshadowInputs[0];
+  const value = element.value;
 
-  resultPage.style.display = 'flex';
+  if (value.length < 3) {
+    getOpenSideBarButton().style.display = 'none';
+  }else{
+    getOpenSideBarButton().style.display = 'flex';
+    resultPage.style.display = 'flex';
+  }
+
   if (type === 'oldResults') return;
 
   const values: Values = {

--- a/src/pages/gradient-background.ts
+++ b/src/pages/gradient-background.ts
@@ -12,6 +12,7 @@ import {
   getCssOrTailwindDropdown,
   getTailwindButton,
   getCssOrTailwindButton,
+  getOpenSideBarButton,
 } from '../lib/getElements';
 import {
   triggerEmptyAnimation,
@@ -55,6 +56,7 @@ export function gradientBackgroundGenerator(
       if (getResultBtn) {
         getResultBtn.style.backgroundColor = 'grey';
       }
+      getOpenSideBarButton().style.display = 'none';
       triggerEmptyAnimation(ele);
     });
     return;

--- a/src/pages/gradient-border.ts
+++ b/src/pages/gradient-border.ts
@@ -14,6 +14,7 @@ import {
   getTailwindButton,
   getCssOrTailwindButton,
   getCssOrTailwindDropdown,
+  getOpenSideBarButton,
 } from '../lib/getElements';
 import {
   copyCSSCodeToClipboard,
@@ -105,7 +106,15 @@ export function gradientBorderGenerator(
   type: 'newResults' | 'oldResults' | null
 ): void {
   if (type === null) return;
-  resultPage.style.display = 'flex';
+  const element = gradientBorderInputs[0];
+  const value = element.value;
+  if (value.length < 3) {
+    getOpenSideBarButton().style.display = 'none';
+  }else{
+    getOpenSideBarButton().style.display = 'flex';
+    resultPage.style.display = 'flex';
+  }
+  
 
   if (type === 'oldResults') return;
 

--- a/src/pages/gradient-text.ts
+++ b/src/pages/gradient-text.ts
@@ -17,6 +17,7 @@ import {
   getCssOrTailwindDropdown,
   getPngOrSvgButton,
   getPngOrSvgDropdown,
+  getOpenSideBarButton,
 } from '../lib/getElements';
 import {
   copyCSSCodeToClipboard,
@@ -96,6 +97,7 @@ export function gradientTextGenerator(
   const getInputElement = getInputText(attribute);
 
   if (getInputElement.value.length === 0) {
+    getOpenSideBarButton().style.display = 'none';
     triggerEmptyAnimation(getInputElement);
     return;
   }

--- a/src/pages/text-shadow.ts
+++ b/src/pages/text-shadow.ts
@@ -18,6 +18,7 @@ import {
   getCssOrTailwindDropdown,
   getPngOrSvgButton,
   getPngOrSvgDropdown,
+  getOpenSideBarButton,
 } from '../lib/getElements';
 import {
   copyCSSCodeToClipboard,
@@ -96,6 +97,7 @@ export function textShadowGenerator(
   const resultPage = getResultPage();
 
   if (getInputElement.value.length === 0) {
+    getOpenSideBarButton().style.display = 'none';
     triggerEmptyAnimation(getInputElement);
     return;
   }


### PR DESCRIPTION
# This pr fixes the issue of open results button showing wrongly

**My PR closes #441 **

# 👨‍💻 Changes proposed(What did you do ?)
I have updated 5 files in total with respect of five pages (in alphabetic order): Box Shadow, Gradient Background, Gradient Border, Gradient Text, and Text Shadow. 

Box Shadow, When no color is picked, clicking the "Get Result" button will not show the side menu button ( I have not added animation like in the Text Shadow page, strickly focusing on the bug itself).
Gradient Background, When the primary/first color is not picked, clicking the "Get Result" button will not show the side menu button.
Gradient Border, When the primary/first color is not picked, clicking the "Get Result" button will not show the side menu button.
Gradient Text, When no text is entered in the top text field, clicking the "Get Result" button will not show the side menu button.
Text Shadow, When no text is entered in the top text field, clicking the "Get Result" button will not show the side menu button.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots
![boxShadow](https://github.com/Dun-sin/Code-Magic/assets/109082755/934efdbe-0275-4022-b661-c3ad64471d50)
![gradientBackground](https://github.com/Dun-sin/Code-Magic/assets/109082755/cf433982-7566-4d46-a261-9b09dc980f19)
![gradientBorder](https://github.com/Dun-sin/Code-Magic/assets/109082755/0da0d4ff-de9a-4abf-a9b7-c1e26317e590)
![gradientText](https://github.com/Dun-sin/Code-Magic/assets/109082755/bc3fcf88-169a-4ce4-a24b-1f6366b351f2)
![textShadow](https://github.com/Dun-sin/Code-Magic/assets/109082755/ffa5ede0-e7fe-4cc0-a4ba-8c168cf48baa)

<!-- Add all the screenshots which support your changes -->
