### PR TITLE
fix: provided error indicator for gradient-border when no input #442

### DIFF
--- a/src/pages/gradient-border.ts
+++ b/src/pages/gradient-border.ts
@@ -14,8 +14,10 @@ import {
   getTailwindButton,
   getCssOrTailwindButton,
   getCssOrTailwindDropdown,
+  getResultButton,
 } from '../lib/getElements';
 import {
+  triggerEmptyAnimation,
   copyCSSCodeToClipboard,
   showPopup,
   addRule,
@@ -41,7 +43,6 @@ const getRemoveColorButtonElement = getRemoveNewColorButton(attribute);
 
 const getBorderRadiusInput = getRadiusInput(attribute);
 const toggleRadiusInputForGradientBorder = getCheckbox(attribute);
-const getOutputElement = getOutput(attribute);
 
 const getDegreeElement = getRange(attribute);
 const resetButton = getResetButton(attribute);
@@ -49,8 +50,6 @@ const getCssOrTailwindDropdownElement = getCssOrTailwindDropdown(attribute);
 const showCopyClass = 'show-css-tailwind';
 
 let gradientBorderInputs = getAllInputElements('gradient-border');
-
-const resultPage = getResultPage();
 
 function copyHandler() {
   const outputElement = getOutput(attribute);
@@ -105,8 +104,34 @@ export function gradientBorderGenerator(
   type: 'newResults' | 'oldResults' | null
 ): void {
   if (type === null) return;
-  resultPage.style.display = 'flex';
 
+  const resultBtn = getResultButton(attribute);
+
+  const item1 = gradientBorderInputs[0];
+  const val1 = item1.value.length;
+
+  const item2 = gradientBorderInputs[1];
+  const val2 = item2.value.length;
+
+  //Show error if input values are empty
+  if ((resultBtn && val1 < 1) || val2 < 1) {
+    gradientBorderInputs.forEach((e) => {
+      if (e.value.length === 0) {
+        triggerEmptyAnimation(e);
+      }
+      resultBtn.style.backgroundColor = 'grey';
+    });
+    return;
+  } else {
+    if (resultBtn) {
+      resultBtn.style.backgroundColor = 'blue';
+    }
+  }
+
+  const getOutputElement = getOutput(attribute);
+  const resultPage = getResultPage();
+
+  resultPage.style.display = 'flex';
   if (type === 'oldResults') return;
 
   if (!toggleRadiusInputForGradientBorder.checked) {


### PR DESCRIPTION
provided error indicator for gradient-border when no input is passed and prevent getting result

# Fixes Issue

**My PR closes #442 **
  
# 👨‍💻 Changes proposed(What did you do ?)
first of all I map the values of `gradientBorderInputs` and check lengths of the values. If the `values.length <1` I called `triggerEmptyAmination` and switched the result-button to `grey` and prevent them from getting results to result-page. 

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots

<!-- Add all the screenshots which support your changes -->
![2023-09-09](https://github.com/Dun-sin/Code-Magic/assets/58364635/d038ef53-18b7-4951-9085-ab65a1490225)

![2023-09-09 (2)](https://github.com/Dun-sin/Code-Magic/assets/58364635/1d985fdf-3f4d-4ad8-88e9-7a318a349564)

![2023-09-09 (3)](https://github.com/Dun-sin/Code-Magic/assets/58364635/37c5e775-c37f-491a-afc6-b0bfd0672b32)

