### PR TITLE
feat(index.html, style.css): add Indication of the active generator/tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,6 +412,9 @@
         <div class="generators">
           <!-- Pic Text -->
           <div data-content="pic-text">
+            <div class="generator-tool-title">
+              <h1>Pic Text</h1>
+            </div>
             <label for="pic-text-file">
               <input type="file" id="pic-text-file" required />
             </label>
@@ -424,6 +427,9 @@
 
           <!-- Gradient Text -->
           <div data-content="gradient-text">
+            <div class="generator-tool-title">
+              <h1>Gradient Text</h1>
+            </div>
             <textarea
               id="gradient-text-text"
               placeholder="Enter the text"
@@ -496,6 +502,9 @@
 
           <!-- Gradient Border -->
           <div data-content="gradient-border">
+            <div class="generator-tool-title">
+              <h1>Gradient Border</h1>
+            </div>
             <div class="colors">
               <label for="color" class="color">
                 <input
@@ -579,6 +588,9 @@
 
           <!-- Gradient Background -->
           <div data-content="gradient-background">
+            <div class="generator-tool-title">
+              <h1>Gradient Background</h1>
+            </div>
             <div class="colors">
               <label for="color" class="color">
                 <input
@@ -652,6 +664,9 @@
 
           <!-- Animation -->
           <div data-content="animation">
+            <div class="generator-tool-title">
+              <h1>Animator</h1>
+            </div>
             <div class="preview-slider"></div>
 
             <div class="animation-type">
@@ -734,6 +749,9 @@
 
           <!-- Border Radius -->
           <div data-content="border-radius">
+            <div class="generator-tool-title">
+              <h1>Border Radius</h1>
+            </div>
             <div class="border-radius-preview-box">
               <div class="preview"></div>
               <div class="border-range-inputs">
@@ -785,6 +803,9 @@
 
           <!-- Box Shadow -->
           <div data-content="box-shadow">
+            <div class="generator-tool-title">
+              <h1>Box Shadow</h1>
+            </div>
             <div class="preview-slider"></div>
 
             <div class="colors">
@@ -874,6 +895,9 @@
 
           <!-- Text Shadow Generator -->
           <div data-content="text-shadow">
+            <div class="generator-tool-title">
+              <h1>Text Shadow</h1>
+            </div>
             <div class="preview-slider"></div>
 
             <textarea
@@ -954,6 +978,9 @@
           <!-- Transform Generator -->
 
           <div data-content="transform">
+            <div class="generator-tool-title">
+              <h1>Transform</h1>
+            </div>
             <div class="preview-slider"></div>
 
             <div class="transform-type">
@@ -1032,6 +1059,9 @@
 
           <!-- Input Type Range Generator -->
           <div data-content="input-range">
+            <div class="generator-tool-title">
+              <h1>Input Range</h1>
+            </div>
             <label for="preview-range">
               <p>Preview</p>
               <input type="range" min="3" max="20" name="" id="preview-range" />

--- a/src/style.css
+++ b/src/style.css
@@ -271,6 +271,17 @@ main > section:last-of-type {
   position: relative;
 }
 
+.generator-tool-title {
+  position: fixed;
+  top: 7%;
+  left: 25%;
+}
+
+.generator-tool-title h1 {
+  font-size: 2.25rem;
+  font-weight: 600;
+}
+
 /* inputs */
 .generators > div {
   display: none;
@@ -1134,6 +1145,10 @@ a {
     margin: 0.8rem auto;
   }
 
+  .generator-tool-title {
+    left: 30%;
+  }
+
   .input {
     padding: 2rem;
   }
@@ -1179,6 +1194,10 @@ a {
 
   .generator {
     margin: 0.8rem auto;
+  }
+
+  .generator-tool-title {
+    left: auto;
   }
 
   footer {


### PR DESCRIPTION
Added a common ".generator-tool-title" class under each generator content in the index.html file. To render the style, updated the style.css file. For rendering the title style, I used fixed position style for them and adjusted the left measurement according to the available media queries. However, when the max-width of the media query is **650** then, it's getting centered. 

# Fixes Issue

**My PR closes #455**

# 👨‍💻 Changes proposed(What did you do ?)
Added an indication (title) of the active generator or tool on the top left corner initially. Centered on the smaller devices.

# ✔️ Check List (Check all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.

##  Note to reviewers
I was unsure about how it should look for the smaller devices. So, I've centered it and used the `left: auto` in the `style.css` file. 

<!-- Add notes to reviewers if applicable -->

# 📷 Screenshots
![image](https://github.com/Dun-sin/Code-Magic/assets/61315959/dfefe2ee-1b89-4ad5-bf5a-785737b98502)


<!-- Add all the screenshots which support your changes -->
