### PR TITLE
fix: Prevent 'Get Results' from Executing When Color Inputs Are Empty 

### DIFF
--- a/src/pages/gradient-text.ts
+++ b/src/pages/gradient-text.ts
@@ -95,7 +95,18 @@ export function gradientTextGenerator(
   if (type === null) return;
 
   const getInputElement = getInputText(attribute);
+  const textAreas = document.querySelectorAll('.gradient-text-inputs');
 
+  // Check if any of the color inputs is empty
+  if (
+    Array.from(textAreas).some(
+      (textArea) => (textArea as HTMLInputElement).value.trim() === ''
+    )
+  ) {
+    return;
+  }
+
+  // If all color inputs are filled
   if (getInputElement.value.length === 0) {
     getOpenSideBarButton().style.display = 'none';
     triggerEmptyAnimation(getInputElement);
@@ -244,7 +255,6 @@ function getValues() {
       if (input.nodeName === 'TEXTAREA') {
         if (input.value === '') return;
       }
-
       if (resetButton.classList.contains('reset-show')) return;
       resetButton.classList.add('reset-show');
     });


### PR DESCRIPTION
# Fixes Issue - [BUG] results open when an added color is empty

**My PR closes #504**

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->

<!--
[x] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [] My code follows the code style of this project.
- [] This PR does not contain plagiarized content.
- [] The title and description of the PR is clear and explains the approach.


<!-- Add notes to reviewers if applicable -->



<!-- Add all the screenshots which support your changes -->
